### PR TITLE
Fixes for ghc 9.6.4

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,31 @@
+name: Check
+on:
+  pull_request:
+
+jobs:
+  build:
+      name: Build and Test
+      runs-on: ubuntu-latest
+      steps:
+        - name: Clone project
+          uses: actions/checkout@v2
+
+        - name: Cache dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.stack
+            key: ${{ runner.os }}-${{ hashFiles('stack.yaml') }}
+            restore-keys: ${{ runner.os }}-
+
+        - name: Setup GHC
+          run: |
+            stack --version
+            stack setup
+
+        - name: Build sources
+          run: |
+            stack build
+
+        - name: Run tests
+          run: |
+            stack test

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
     - env: ARGS="--resolver=lts-15"
     - env: ARGS="--resolver=lts-16"
     - env: ARGS="--resolver=lts-17"
+    - env: ARGS="--resolver=lts-22"
     - env: ARGS="--resolver=nightly"
   allow_failures:
     - env: ARGS="--resolver=nightly"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+1.0.0.0
+* Removed `return` from the `Monad` instance for `Parser`, and
+  transfered its definition to `pure` in the `Applicative` instance of
+  `Parser`. This was necessary to support GHC 9.6.4.
+* Create new API to choose whether to handle empty CSV cells as empty
+  strings or NULLs.
+* Added imports that were removed from `Prelude` in GHC 9.6.4.
+* Bumped the default Stack resolver to LTS-22.20.
+
 0.7.3.0
 * Add ordered versions of named records for consistent, controllable header column ordering. [PR 44](https://github.com/ozataman/csv-conduit/pull/44)
 * Add support for GHC 9.0.1

--- a/csv-conduit.cabal
+++ b/csv-conduit.cabal
@@ -1,27 +1,34 @@
-Name:                csv-conduit
-Version:             0.8.0.0
-Synopsis:            A flexible, fast, conduit-based CSV parser library for Haskell.
-Homepage:            http://github.com/ozataman/csv-conduit
-License:             BSD3
-License-file:        LICENSE
-Author:              Ozgun Ataman
-Maintainer:          Ozgun Ataman <ozataman@gmail.com>
-Category:            Data, Conduit, CSV, Text
-Build-type:          Simple
-Cabal-version:       >= 1.10
-Tested-with:         GHC == 9.0.1, GHC == 8.10.4, GHC == 8.8.4, GHC == 8.8.3, GHC == 8.6.5, GHC == 8.4.4, GHC == 8.2.2
-Description:
+name:               csv-conduit
+version:            1.0.0.0
+synopsis:
+  A flexible, fast, conduit-based CSV parser library for Haskell.
+
+homepage:           http://github.com/ozataman/csv-conduit
+license:            BSD3
+license-file:       LICENSE
+author:             Ozgun Ataman
+maintainer:         Ozgun Ataman <ozataman@gmail.com>
+category:           Data, Conduit, CSV, Text
+build-type:         Simple
+cabal-version:      >=1.10
+tested-with:
+  GHC ==8.2.2
+   || ==8.4.4
+   || ==8.6.5
+   || ==8.8.3
+   || ==8.8.4
+   || ==8.10.4
+   || ==9.0.1
+   || ==9.6.4
+
+description:
   CSV files are the de-facto standard in many situations involving data transfer,
   particularly when dealing with enterprise application or disparate database
   systems.
-
   .
-
   While there are a number of CSV libraries in Haskell, at the time of this
   project's start in 2010, there wasn't one that provided all of the following:
-
   .
-
   * Full flexibility in quote characters, separators, input/output
   .
   * Constant space operation
@@ -32,106 +39,103 @@ Description:
   .
   * Fast operation
   .
-
   This library is an attempt to close these gaps. Please note that
   this library started its life based on the enumerator package and
   has recently been ported to work with conduits instead. In the
   process, it has been greatly simplified thanks to the modular nature
   of the conduits library.
-
   .
-
   Following the port to conduits, the library has also gained the
   ability to parameterize on the stream type and work both with
   ByteString and Text.
-
   .
-
   For more documentation and examples, check out the README at:
   .
-
   <http://github.com/ozataman/csv-conduit>
   .
 
-
 extra-source-files:
-  README.md
   changelog.md
+  README.md
   test/test.csv
   test/Test.hs
 
 flag lib-Werror
   default: False
-  manual: True
+  manual:  True
 
 library
   default-language: Haskell2010
   exposed-modules:
-      Data.CSV.Conduit
-      Data.CSV.Conduit.Types
-      Data.CSV.Conduit.Conversion
-      Data.CSV.Conduit.Parser.ByteString
-      Data.CSV.Conduit.Parser.Text
+    Data.CSV.Conduit
+    Data.CSV.Conduit.Conversion
+    Data.CSV.Conduit.Parser.ByteString
+    Data.CSV.Conduit.Parser.Text
+    Data.CSV.Conduit.Types
+
   other-modules:
-      Data.CSV.Conduit.Conversion.Internal
-      Data.CSV.Conduit.Monoid
-  ghc-options: -Wall -funbox-strict-fields
-  if flag(lib-Werror)
+    Data.CSV.Conduit.Conversion.Internal
+    Data.CSV.Conduit.Monoid
+
+  ghc-options:      -Wall -funbox-strict-fields
+
+  if flag(lib-werror)
     ghc-options: -Werror
-  hs-source-dirs: src
+
+  hs-source-dirs:   src
   build-depends:
-      attoparsec             >= 0.10
-    , base                   >= 4 && < 5
-    , bytestring
-    , conduit                >= 1.2.8
-    , conduit-extra
-    , containers             >= 0.3
-    , exceptions             >= 0.3
-    , monad-control
-    , text
-    , data-default
-    , vector
-    , array
+      array
+    , attoparsec            >=0.10
+    , base                  >=4       && <5
     , blaze-builder
-    , unordered-containers
-    , ordered-containers
-    , transformers
-    , mtl
+    , bytestring
+    , conduit               >=1.2.8
+    , conduit-extra
+    , containers            >=0.3
+    , data-default
+    , exceptions            >=0.3
     , mmorph
+    , monad-control
+    , mtl
+    , ordered-containers
     , primitive
-    , resourcet              >= 1.1.2.1
+    , resourcet             >=1.1.2.1
     , semigroups
+    , text
+    , transformers
+    , unordered-containers
+    , vector
 
-  if impl(ghc >= 7.2.1)
-    cpp-options: -DGENERICS
-    build-depends: ghc-prim >= 0.2
-
+  if impl(ghc >=7.2.1)
+    cpp-options:   -DGENERICS
+    build-depends: ghc-prim >=0.2
 
 test-suite test
   default-language: Haskell2010
-  type: exitcode-stdio-1.0
-  main-is: Test.hs
-  ghc-options: -Wall
-  if flag(lib-Werror)
+  type:             exitcode-stdio-1.0
+  main-is:          Test.hs
+  ghc-options:      -Wall
+
+  if flag(lib-werror)
     ghc-options: -Werror
-  hs-source-dirs: test
+
+  hs-source-dirs:   test
   build-depends:
-      base >= 4 && < 5
+      base                  >=4     && <5
     , bytestring
-    , conduit >= 1.3.0
-    , containers >= 0.3
+    , conduit               >=1.3.0
+    , containers            >=0.3
     , csv-conduit
     , directory
-    , vector
-    , HUnit >= 1.2
+    , HUnit                 >=1.2
+    , mtl
+    , ordered-containers
+    , primitive
     , test-framework
     , test-framework-hunit
     , text
-    , ordered-containers
     , transformers
-    , mtl
-    , primitive
-
+    , vector
 
 source-repository head
   type:     git

--- a/src/Data/CSV/Conduit.hs
+++ b/src/Data/CSV/Conduit.hs
@@ -39,8 +39,10 @@ import           Control.Exception
 import           Control.Monad.Catch.Pure           (CatchT)
 import           Control.Monad.Catch.Pure           (runCatchT)
 import           Control.Monad.Except
+import           Control.Monad.IO.Class             (MonadIO (liftIO))
 import           Control.Monad.Primitive
 import           Control.Monad.ST
+import           Control.Monad.Trans.Class          (lift)
 import           Control.Monad.Trans.Resource       (MonadResource, MonadThrow,
                                                      runResourceT)
 import           Data.Attoparsec.Types              (Parser)

--- a/src/Data/CSV/Conduit/Conversion.hs
+++ b/src/Data/CSV/Conduit/Conversion.hs
@@ -160,7 +160,7 @@ type Field = B8.ByteString
 -- >         | otherwise     = mzero
 class FromRecord a where
     parseRecord :: Record -> Parser a
-
+  
 #ifdef GENERICS
     default parseRecord :: (Generic a, GFromRecord (Rep a)) => Record -> Parser a
     parseRecord r = to A.<$> gparseRecord r
@@ -792,10 +792,11 @@ instance Functor Parser where
     {-# INLINE fmap #-}
 
 instance Applicative Parser where
-    pure  = pure
-    {-# INLINE pure #-}
+
     (<*>) = apP
     {-# INLINE (<*>) #-}
+    pure a = Parser $ \_kf ks -> ks a
+    {-# INLINE pure #-}
 
 instance Alternative Parser where
     empty = fail "empty"
@@ -818,7 +819,7 @@ apP :: Parser (a -> b) -> Parser a -> Parser b
 apP d e = do
   b <- d
   a <- e
-  pure (b a)
+  return (b a)
 {-# INLINE apP #-}
 
 -- | Run a 'Parser', returning either @'Left' errMsg@ or @'Right'
@@ -840,9 +841,9 @@ class GFromRecord f where
     gparseRecord :: Record -> Parser (f p)
 
 instance GFromRecordSum f Record => GFromRecord (M1 i n f) where
-    gparseRecord v =
+    gparseRecord v = 
         case (IM.lookup n gparseRecordSum) of
-            Nothing -> lengthMismatch n v
+            Nothing -> lengthMismatch n v 
             Just p -> M1 <$> p v
       where
         n = V.length v
@@ -851,15 +852,15 @@ class GFromNamedRecord f where
     gparseNamedRecord :: NamedRecord -> Parser (f p)
 
 instance GFromRecordSum f NamedRecord => GFromNamedRecord (M1 i n f) where
-    gparseNamedRecord v =
+    gparseNamedRecord v = 
         foldr (\f p -> p <|> M1 <$> f v) empty (IM.elems gparseRecordSum)
 
 class GFromRecordSum f r where
     gparseRecordSum :: IM.IntMap (r -> Parser (f p))
 
 instance (GFromRecordSum a r, GFromRecordSum b r) => GFromRecordSum (a :+: b) r where
-    gparseRecordSum =
-        IM.unionWith (\a b r -> a r <|> b r)
+    gparseRecordSum = 
+        IM.unionWith (\a b r -> a r <|> b r) 
             (fmap (L1 <$>) <$> gparseRecordSum)
             (fmap (R1 <$>) <$> gparseRecordSum)
 

--- a/src/Data/CSV/Conduit/Conversion.hs
+++ b/src/Data/CSV/Conduit/Conversion.hs
@@ -160,7 +160,7 @@ type Field = B8.ByteString
 -- >         | otherwise     = mzero
 class FromRecord a where
     parseRecord :: Record -> Parser a
-  
+
 #ifdef GENERICS
     default parseRecord :: (Generic a, GFromRecord (Rep a)) => Record -> Parser a
     parseRecord r = to A.<$> gparseRecord r
@@ -841,9 +841,9 @@ class GFromRecord f where
     gparseRecord :: Record -> Parser (f p)
 
 instance GFromRecordSum f Record => GFromRecord (M1 i n f) where
-    gparseRecord v = 
+    gparseRecord v =
         case (IM.lookup n gparseRecordSum) of
-            Nothing -> lengthMismatch n v 
+            Nothing -> lengthMismatch n v
             Just p -> M1 <$> p v
       where
         n = V.length v
@@ -852,15 +852,15 @@ class GFromNamedRecord f where
     gparseNamedRecord :: NamedRecord -> Parser (f p)
 
 instance GFromRecordSum f NamedRecord => GFromNamedRecord (M1 i n f) where
-    gparseNamedRecord v = 
+    gparseNamedRecord v =
         foldr (\f p -> p <|> M1 <$> f v) empty (IM.elems gparseRecordSum)
 
 class GFromRecordSum f r where
     gparseRecordSum :: IM.IntMap (r -> Parser (f p))
 
 instance (GFromRecordSum a r, GFromRecordSum b r) => GFromRecordSum (a :+: b) r where
-    gparseRecordSum = 
-        IM.unionWith (\a b r -> a r <|> b r) 
+    gparseRecordSum =
+        IM.unionWith (\a b r -> a r <|> b r)
             (fmap (L1 <$>) <$> gparseRecordSum)
             (fmap (R1 <$>) <$> gparseRecordSum)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.11
+resolver: lts-22.20
 packages:
   - .
 extra-deps:

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -9,6 +9,7 @@ import Control.Exception
 import qualified Data.ByteString.Char8 as B
 import Data.CSV.Conduit
 import Data.CSV.Conduit.Conversion
+import Data.CSV.Conduit.Types
 import qualified Data.Map as Map
 import qualified Data.Map.Ordered as OMap
 import Data.Monoid as M
@@ -106,7 +107,7 @@ test_orderedMap = do
     pairs = [("b", "bval"), ("a", "aval")]
 
 csvSettings :: CSVSettings
-csvSettings = defCSVSettings {csvQuoteChar = Just '`'}
+csvSettings = defCSVSettings {csvQuoteCharAndStyle = Just ('`', DontQuoteEmpty)}
 
 testFile1, testFile2 :: FilePath
 testFile1 = "test/test.csv"


### PR DESCRIPTION
* Removed `return` from the `Monad` instance for `Parser`, and
  transfered its definition to `pure` in the `Applicative` instance of
  `Parser`. This was necessary to support GHC 9.6.4.
* Create new API to choose whether to handle empty CSV cells as empty
  strings or NULLs.
* Added imports that were removed from `Prelude` in GHC 9.6.4.
* Bumped the default Stack resolver to LTS-22.20.
